### PR TITLE
Suppress kill msg and trap keyboard interrupt

### DIFF
--- a/testbed/detect_collision.py
+++ b/testbed/detect_collision.py
@@ -25,6 +25,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     signal.signal(signal.SIGALRM, handler)
+    signal.signal(signal.SIGINT, handler)
     signal.alarm(timeout)
 
     data = ""

--- a/testbed/detect_takeoff.py
+++ b/testbed/detect_takeoff.py
@@ -16,6 +16,7 @@
 import math
 import sys
 import re
+import signal
 
 def dist(x, y, z):
     return math.sqrt(x * x + y * y + z * z)
@@ -23,6 +24,11 @@ def dist(x, y, z):
 if __name__ == '__main__':
     takeoff_distance = float(sys.argv[1])
     pos_re = re.compile("position\ \{\ *x\:(.+)y\:(.+)z\:(.+)\}\ orientation.*")
+
+    def handler(signum, frame):
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, handler)
 
     for line in sys.stdin:
         m = pos_re.match(line)


### PR DESCRIPTION
closes #9
closes #3

Shell outputs a 'job killed' message that needs to be suppressed in orther for
silent-kill to work as expected. Those messages have been suppressed with the
'wait' command - that is called subsequently to a successful "kill -KILL"
command.

Ctrl-C has also been trapped in order to make sure all child jobs terminate
properly in case the user aborts the execution of the script.

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
