### PR TITLE
Change default MavQuadCopter mavlink port

### DIFF
--- a/vehicles/MavQuadCopter.cc
+++ b/vehicles/MavQuadCopter.cc
@@ -29,7 +29,7 @@
 
 namespace defaults
 {
-const uint16_t local_port = 14557;
+const uint16_t local_port = 15557;
 const double wp_equal_dist_m = 0.001;
 }
 


### PR DESCRIPTION
The default port MavQuadCopter chooses to bind to is coincidentally the same as
PX4. Since a port can't be bound twice, this will certainly cause problems when
both programs run with their defaults. This patch changes MavQuadCopter default
mavlink port in order to avoid those problems.

Signed-off-by: Guilherme Campos Camargo guilherme.campos.camargo@intel.com
