### PR TITLE
Fix DepthImagePolarHistDetector

### DIFF
--- a/detection/DepthImagePolarHistDetector.cc
+++ b/detection/DepthImagePolarHistDetector.cc
@@ -36,11 +36,11 @@ const std::vector<double> &DepthImagePolarHistDetector::detect()
 {
 
     // Obtain camera depth buffer and camera properties
-    std::vector<uint16_t> depth_buffer = this->depth_camera->get_depth_buffer();
-    unsigned int height = this->depth_camera->get_height();
-    unsigned int width = this->depth_camera->get_width();
-    double fov_tan = this->depth_camera->get_fov_tan();
-    double scale = this->depth_camera->get_scale();
+    std::vector<uint16_t> depth_buffer = this->sensor->get_depth_buffer();
+    unsigned int height = this->sensor->get_height();
+    unsigned int width = this->sensor->get_width();
+    double fov_tan = this->sensor->get_fov_tan();
+    double scale = this->sensor->get_scale();
 
     // Return an empty histogram if the depth buffer is invalid
     if(depth_buffer.size() == 0) {

--- a/detection/DepthImagePolarHistDetector.hh
+++ b/detection/DepthImagePolarHistDetector.hh
@@ -27,7 +27,6 @@ class DepthImagePolarHistDetector : public Detector<DepthCamera, double>
     const std::vector<double> &detect() override;
 
   private:
-    std::shared_ptr<DepthCamera> depth_camera;
     double angle_step;
     std::vector<double> histogram;
 };


### PR DESCRIPTION
After the change to the Detector API, the DepthImagePolarHistDetector
member depth_camera was replaced by the sensor membern the parent class, but
the old depth_camera was still present and still being used in the code.