### PR TITLE
Add missing include directories to RealSenseCamera

### DIFF
--- a/sensors/CMakeLists.txt
+++ b/sensors/CMakeLists.txt
@@ -9,11 +9,16 @@ set(LIBRARIES
     ${GAZEBO_LIBRARIES}
 )
 
+set(INCLUDES
+)
+
 if(REALSENSE_FOUND)
     set(SOURCES ${SOURCES} RealSenseCamera.cc)
     set(LIBRARIES ${LIBRARIES} ${REALSENSE_LIBRARIES})
-endif(REALSENSE_FOUND)
+    set(INCLUDES ${INCLUDES} ${REALSENSE_INCLUDE_DIRS})
+endif()
 
 add_library(sensors ${SOURCES})
 target_link_libraries(sensors ${LIBRARIES} ${LDFLAGS})
+target_include_directories(sensors PRIVATE ${INCLUDES})
 


### PR DESCRIPTION
If RealSense headers were out of the default include path, the build
would fail. This patch adds the missing include parameters to cmake.