### PR TITLE
Bootstrap coav Yocto layer

### DIFF
--- a/meta-coav/README
+++ b/meta-coav/README
@@ -1,0 +1,1 @@
+Collision Avoidance Library Yocto Layer

--- a/meta-coav/conf/layer.conf
+++ b/meta-coav/conf/layer.conf
@@ -1,0 +1,10 @@
+BBPATH .= ":${LAYERDIR}"
+
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "coav"
+BBFILE_PATTERN_coav = "^${LAYERDIR}/"
+BBFILE_PRIORITY_coav = "1"
+
+LAYERVERSION_coav = "1"

--- a/meta-coav/recipes-coav/coav-control/coav-control_0.0.1.bb
+++ b/meta-coav/recipes-coav/coav-control/coav-control_0.0.1.bb
@@ -1,0 +1,37 @@
+# coav-control.bb
+SUMMARY = "Collision avoidance test application."
+HOMEPAGE = "https://github.com/01org/collision-avoidance-library"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=93888867ace35ffec2c845ea90b2e16b"
+
+DEPENDS = "glm librealsense python-future"
+RDEPENDS_${PN} = "librealsense"
+
+SRCREV = "${AUTOREV}"
+SRC_URI = "gitsm://git@github.com/01org/collision-avoidance-library.git;protocol=https;branch=master"
+
+S = "${WORKDIR}/git"
+
+inherit cmake pythonnative
+
+EXTRA_OECMAKE = "-DWITH_TOOLS=ON -DWITH_REALSENSE=ON"
+
+do_configure_prepend() {
+    export PYTHONPATH="${PKG_CONFIG_SYSROOT_DIR}/usr/lib/python2.7/site-packages/"
+}
+
+do_install_append () {
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${B}/tools/coav-control/coav-control.sh ${D}${sysconfdir}/init.d
+
+    install -d ${D}${sysconfdir}/rc1.d
+    ln -sf ../init.d/coav-control.sh ${D}${sysconfdir}/rc1.d/S81coav-control
+    install -d ${D}${sysconfdir}/rc2.d
+    ln -sf ../init.d/coav-control.sh ${D}${sysconfdir}/rc2.d/S81coav-control
+    install -d ${D}${sysconfdir}/rc3.d
+    ln -sf ../init.d/coav-control.sh ${D}${sysconfdir}/rc3.d/S81coav-control
+    install -d ${D}${sysconfdir}/rc4.d
+    ln -sf ../init.d/coav-control.sh ${D}${sysconfdir}/rc4.d/S81coav-control
+    install -d ${D}${sysconfdir}/rc5.d
+    ln -sf ../init.d/coav-control.sh ${D}${sysconfdir}/rc5.d/S81coav-control
+}

--- a/meta-coav/recipes-support/glm/glm_0.9.8.bb
+++ b/meta-coav/recipes-support/glm/glm_0.9.8.bb
@@ -1,0 +1,15 @@
+# glm.bb
+SUMMARY = "OpenGL Mathematics (GLM)."
+DESCRIPTION = "C++ mathematics library for graphics software based on the GLSL spec."
+HOMEPAGE = "https://github.com/g-truc/glm"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://copying.txt;md5=4431606d144252143c9c3df384a74cad"
+
+SRCREV = "${AUTOREV}"
+SRC_URI = "gitsm://git@github.com/g-truc/glm.git;protocol=https;branch=0.9.8"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+FILES_${PN}-dev += "${libdir}/cmake"


### PR DESCRIPTION
This layer contains recipes to build and install coav-control and it's
init script on a Yocto image.

This patch was tested on the Intel Aero Yocto build and due the python
recipes provided by the version of meta-openembedded on the build, a
custom configure step is needed in order to use python to build the
Mavlink headers. Once meta-openembedded gets updated to a newer version,
that task may be removed.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>

#58 