### PR TITLE
Fix Polar Histogram Detector

### DIFF
--- a/src/detection/DepthImagePolarHistDetector.cc
+++ b/src/detection/DepthImagePolarHistDetector.cc
@@ -101,7 +101,7 @@ const std::vector<Obstacle> &DepthImagePolarHistDetector::detect()
         double phi = max_phi - (i * fixed_step) - (fixed_step / 2);
 
         Obstacle obs;
-        obs.center = glm::dvec3(histogram[i], 0.0, phi);
+        obs.center = glm::dvec3(histogram[i], M_PI / 2, phi);
         this->obstacles.push_back(obs);
     }
 


### PR DESCRIPTION
The obstacle should be right in front of the vehicle, where phi is 90
degrees ( pi/2 rad).

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>