### PR TITLE
[detector] Fix Obstacle Detector init

### DIFF
--- a/src/detection/DepthImageObstacleDetector.cc
+++ b/src/detection/DepthImageObstacleDetector.cc
@@ -214,6 +214,7 @@ int DepthImageObstacleDetector::extract_blobs()
 
     // Check if the current stored depth frame is valid
     if (depth_frame.size() == 0) {
+        obstacles.resize(0);
         return 0;
     }
 


### PR DESCRIPTION
If obstacle detector received an empty depth_frame it would return
without setting the size of the obstacles vector, causing the vector to
have UINT16_MAX size and invalid data.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>