### PR TITLE
[testbed] set mission speed

### DIFF
--- a/testbed/coav-sim.sh
+++ b/testbed/coav-sim.sh
@@ -85,6 +85,7 @@ run_autopilot () {
         # Fetch copter parameters file
         if [ ! -f copter.parm ]; then
             wget ${APM_PARM_URL}
+            echo "WPNAV_SPEED 100" >> ./copter.parm
             wait $!
 
             if [ ! -f copter.parm ]; then


### PR DESCRIPTION
Set mission speed to 1m/s to allow time for breaking.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>